### PR TITLE
Error in constructor of class NodeLinesItem

### DIFF
--- a/pyemtmad/types.py
+++ b/pyemtmad/types.py
@@ -447,7 +447,6 @@ class NodeLinesItem(object):
         for line in lines:
             if line:
                 elements = line.replace('\\', '').strip().split('/')
-                print(elements)
                 # 1 = forward, 2 = backward
                 direction = 'forward' if elements[1] == '1' else 'backward'
                 self.lines.append((int(elements[0]), direction))

--- a/pyemtmad/types.py
+++ b/pyemtmad/types.py
@@ -445,11 +445,12 @@ class NodeLinesItem(object):
         self.lines = []
 
         for line in lines:
-            elements = line.replace('\\', '').strip().split('/')
-
-            # 1 = forward, 2 = backward
-            direction = 'forward' if elements[1] == '1' else 'backward'
-            self.lines.append((int(elements[0]), direction))
+            if line:
+                elements = line.replace('\\', '').strip().split('/')
+                print(elements)
+                # 1 = forward, 2 = backward
+                direction = 'forward' if elements[1] == '1' else 'backward'
+                self.lines.append((int(elements[0]), direction))
 
         self._json = kwargs
 


### PR DESCRIPTION
In constructor function on class NodeLinesItem in line 444 "kwars.get('lines')" return a list, whose first index is ['']. As a consequence,when you pass like parameter of the function get_nodes_lines of class BusApi  any integer or a list of integers the functions return this error (in my case, the error is given in path where i installed python):
Traceback (most recent call last):
  File "emt.py", line 2, in <module>
    from pyemtmad import Wrapper
  File "C:\Python\Python36\lib\site-packages\pyemtmad__init__.py", line 1, in <
module>
    from pyemtmad.wrapper import Wrapper
  File "C:\Python\Python36\lib\site-packages\pyemtmad\wrapper.py", line 25, in <
module>
    from pyemtmad.api.bus import BusApi
  File "C:\Python\Python36\lib\site-packages\pyemtmad\api\bus.py", line 24, in <
module>
    from pyemtmad import types as emtype
  File "C:\Python\Python36\lib\site-packages\pyemtmad\types.py", line 449
    print(elements)
Add this list "if line:" in for it solve the problem.
